### PR TITLE
npm scripts to fix canister types file

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -23,7 +23,6 @@
       "packtool": ""
     }
   },
-  "dfx": "0.7.0-beta.8",
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "deploy": "dfx deploy Hello",
+    "postdeploy": "node ./scripts/fix-canister-typing.js"
   },
   "private": true,
   "dependencies": {

--- a/scripts/fix-canister-typing.js
+++ b/scripts/fix-canister-typing.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+const additionalTypes = `
+export const idlFactory: any;
+export const canisterId: string;`;
+
+const typesFileName = './.dfx/local/canisters/Hello/Hello.d.ts';
+const typesFile = fs.readFileSync(typesFileName).toString();
+
+if(typesFile.indexOf(additionalTypes) === -1) {
+  // append data to a file
+  fs.appendFile(typesFileName, additionalTypes, (err) => {
+      if (err) {
+          throw err;
+      }
+      console.log("File is updated.");
+  });
+} else {
+  console.log('already defined');
+}

--- a/src/app/services/actor.service.ts
+++ b/src/app/services/actor.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Actor, HttpAgent } from '@dfinity/agent';
-import { canisterId as Hello_canister_id, idlFactory as Hello_idl } from 'dfx-generated/hello';
-import _SERVICE from 'dfx-service/hello';
+import _SERVICE, { canisterId as Hello_canister_id, idlFactory as Hello_idl } from 'dfx-service/hello';
 
 import dfxConfig from '../../../dfx.json';
 

--- a/src/typings/typings.d.ts
+++ b/src/typings/typings.d.ts
@@ -1,4 +1,0 @@
-declare module 'dfx-generated/hello' {
-  export const idlFactory: any;
-  export const canisterId: string;
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
       "./node_modules/@types"
     ],
     "paths": {
-      "dfx-generated/*": [".dfx/local/canisters/hello/*"],
       "dfx-service/*": [".dfx/local/canisters/hello/*"]
     }
   },


### PR DESCRIPTION
Adding a couple of npm scripts to avoid other convoluted workarounds.

`deploy` script added for deploying backend canister. The only purpose of this as opposed to just using `dfx deploy Hello` explicitly is to leverage the `postdeploy` script that accompanies it. The `postdeploy` script will add the canisterId and idlFactory exports to the generated canister's types file.

The canister name and environment are currently hardcoded. Ideally, these would be made dynamic.